### PR TITLE
Allow extra data to be stored along with the Cart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 *.swp
 *.un~
 *.rdb
+.idea/

--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ The `Cart` object also has some handy methods that you should be aware of:
 - `destroy!` - which will delete the cart, and all the line_items out of it.
 - `reassign(id)` - this method will reassign the cart's unique identifier.  So to access this cart at a later time after reassigning, you would put `Cart.new(reassigned_id)`.  This is useful for having a cart for an unsigned in user.  You can use their session ID while they're unauthenticated, and then when they sign in, you can reassign the cart to the user's ID.  NOTE: Reassigning will overwrite any cart in it's way.
 
+The `Cart` object exposes an `extra[]` object that works like and Array and can be used to store extra data along with the `Cart` instance.
+`Cart#extra[]` can store `Numeric, Float, String, Boolean` and even `Array` or `Hash` values. Just remember that data in Redis is always stored as a String. So you have to coerce values back to original type by yourself.
+
+```ruby
+cart = Cartman::Cart.new(id)
+cart.extra['discount'] = 10
+cart.extra['discount'] == '10' # !
+cart.extra['discounted'] = true
+cart.extra['discounted'] == 'true' # !
+cart.extra['extra_array'] = [ 1, 2, 3 ]
+cart.extra['extra_array'] == [ '1', '2', '3'] # !
+cart.extra['discount'] = { discounted: true, discount: 30 }
+cart.extra['discount'] == { discounted: 'true', discount: '30' } # keys are symbolized but values are still String instances
+cart.extra[2] # raises an ArgumentError: keys must be Strings
+```
+
+The `Cart#extra[]` properties are destroyed with the Cart, they `touch` the Cart when created or changed (so `Cart#version` gets incremented) and they follow the other Cart keys if Cart's unique identifier is changed using `Cart#reassign(new_id)`
+
 Lets walk through an example implementation with a Rails app that has a User model and a Product model.
 
 ```ruby
@@ -103,6 +121,34 @@ end
 %ul
   - @cart.items.each do |item|
     %li #{item.name} - #{item.cost}
+```
+
+## Sample usage of Cart#extra[]
+
+```ruby
+# app/controllers/products_controller.rb
+class ProductsController < ApplicationController
+  #...
+  # /products/:id/add_to_cart
+  def add_to_cart
+    @product = Product.find(params[:id])
+    current_user.cart.add_item(id: @product.id, name: @product.name, unit_cost: @product.cost, cost: @product.cost * params[:quantity], quantity: params[:quantity])
+  end
+  #...
+ 
+  def store_discount_code
+    current_user.cart.extra['discount_code'] = params[:discount_code] 
+  end
+end
+```
+
+```haml
+-# app/view/cart/show.html.haml
+%h1 Cart - Total: #{@cart.total}
+%ul
+  - @cart.items.each do |item|
+    %li #{item.name} - #{item.cost}
+  %li Discount Code: #{@cart.extra['discount_code']}  
 ```
 
 ## Contributing

--- a/lib/cartman.rb
+++ b/lib/cartman.rb
@@ -1,3 +1,4 @@
+require "bigdecimal"
 require "cartman/version"
 require "cartman/configuration"
 require "cartman/cart"

--- a/lib/cartman.rb
+++ b/lib/cartman.rb
@@ -4,6 +4,7 @@ require "cartman/configuration"
 require "cartman/cart"
 require "cartman/item"
 require "cartman/item_collection"
+require "cartman/extra"
 
 module Cartman
   def self.config

--- a/lib/cartman/cart.rb
+++ b/lib/cartman/cart.rb
@@ -59,8 +59,8 @@ module Cartman
 
     def total
       items.collect { |item|
-        (item.cost * 100).to_i
-      }.inject(0){|sum,cost| sum += cost} / 100.0
+        item.cost
+      }.inject(BigDecimal("0")){|sum,cost| sum += cost}
     end
 
     def ttl

--- a/lib/cartman/extra.rb
+++ b/lib/cartman/extra.rb
@@ -1,0 +1,62 @@
+module Cartman
+  class Extra
+    def initialize(cart_id)
+      @cart_id = cart_id
+    end
+
+    def cart
+      @cart ||= Cart.new(@cart_id)
+    end
+
+    def cart_key
+      @cart_key ||= cart.send(:key)
+    end
+
+    def [](name)
+      raise ArgumentError, "extra[] key name must be a String" unless name.is_a?(String)
+
+      key = extra_key(name)
+
+      case key_type = redis.type(key).to_sym
+      when :string then
+        redis.get key
+      when :set then
+        redis.smembers key
+      when :hash then
+        redis.hgetall(key).inject({}) { |hash, (k, v)| hash[k.to_sym] = v; hash }
+      when :none then
+        nil
+      else
+        raise ArgumentError, "#{key_type} is not supported"
+      end
+    end
+
+    def []=(name, value)
+      raise ArgumentError, "extra[] key name must be a String" unless name.is_a?(String)
+
+      key = extra_key(name)
+      redis.del(key) if redis.exists(key)
+      case value
+      when Hash then
+        redis.mapped_hmset key, value
+      when Array then
+        redis.sadd key, value
+      else
+        redis.set key, value unless value.nil?
+      end
+      cart.touch
+      value
+    end
+
+    def extra_key(name)
+      "#{cart_key}:extra:#{name}"
+    end
+
+    private
+
+    def redis
+      Cartman.config.redis
+    end
+
+  end
+end

--- a/lib/cartman/item.rb
+++ b/lib/cartman/item.rb
@@ -11,9 +11,9 @@ module Cartman
     end
 
     def cost
-      unit_cost = (@data.fetch(Cartman.config.unit_cost_field).to_f * 100).to_i
+      unit_cost = BigDecimal(@data.fetch(Cartman.config.unit_cost_field))
       quantity = @data.fetch(Cartman.config.quantity_field).to_i
-      (unit_cost * quantity) / 100.0
+      (unit_cost * quantity)
     end
 
     def cart

--- a/lib/cartman/version.rb
+++ b/lib/cartman/version.rb
@@ -1,3 +1,3 @@
 module Cartman
-  VERSION = "2.1.2"
+  VERSION = "2.5.0"
 end

--- a/spec/extra_keys_spec.rb
+++ b/spec/extra_keys_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+
+describe Cartman do
+  describe Cartman::Cart do
+    let(:cart) { Cartman::Cart.new(1) }
+
+    before(:each) do
+      Cartman.config.redis.flushdb
+    end
+
+    describe "extra_key" do
+      it "should be type of Cart::Extra" do
+        expect(cart.extra).to be_a(Cartman::Extra)
+      end
+
+      it "should store a Boolean as a String" do
+        cart.extra['self_picking'] = true
+        expect(cart.extra['self_picking']).to eq('true')
+      end
+
+      it "should store a number as a String" do
+        cart.extra['discount'] = 10
+        expect(cart.extra['discount']).to eq('10')
+
+        # Make sure key really exists in Redis
+        expect(Cartman.config.redis.exists("cartman:cart:1:extra:discount")).to be true
+        expect(Cartman.config.redis.get("cartman:cart:1:extra:discount")).to eq('10')
+      end
+
+      it "should store a String" do
+        cart.extra['code'] = 'XB22'
+        expect(cart.extra['code']).to eq('XB22')
+      end
+
+      it "should store a BigDecimal" do
+        cart.extra['discount'] = BigDecimal(1.25, 2)
+        expect(BigDecimal(cart.extra['discount'])).to eq(BigDecimal(1.25, 2))
+      end
+
+      it "should store an Array as a set of Strings" do
+        cart.extra['test'] = [ 1, 2, 3 ]
+        test = cart.extra['test']
+        expect(test).to be_an_instance_of(Array)
+        expect(test.length).to be(3)
+        expect(test).to match_array([1, 2, 3].map(&:to_s))
+      end
+
+      it "should store a Hash as a map of Strings Values" do
+        cart.extra['test'] = { a: 1, b: 2 }
+        test = cart.extra['test']
+        expect(test).to be_an_instance_of(Hash)
+        expect(test).to eq({a: '1', b: '2'})
+      end
+
+      it "should overwrite previous values" do
+        cart.extra['self_picking'] = false
+        cart.extra['self_picking'] = true
+        expect(cart.extra['self_picking']).to eq('true')
+      end
+
+      it "should remove extra keys when assigned nil" do
+        cart.extra['discount'] = 10
+        cart.extra['discount'] = nil
+        expect(Cartman.config.redis.exists("cartman:cart:1:extra:discount")).to be false
+      end
+
+      it "should raise an error if extra[] key is anything but a String" do
+        expect { cart.extra[2] }.to raise_error(ArgumentError)
+        expect { cart.extra[2] = 'test' }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe "#destroy" do
+      it "should delete the extra keys" do
+        cart.extra['self_picking'] = true
+        cart.destroy!
+        expect(Cartman.config.redis.exists("cartman:cart:1")).to be false
+        expect(Cartman.config.redis.exists("cartman:cart:1:extra:self_picking")).to be false
+      end
+    end
+
+    describe "#touch" do
+      it "should reset the TTL" do
+        cart.extra['self_picking'] = true
+        cart.touch
+        expect(Cartman.config.redis.ttl("cartman:cart:1:extra:self_picking")).to eq(Cartman.config.cart_expires_in)
+      end
+
+      it "should record that the cart was updated" do
+        cart.extra['self_picking'] = true
+        cart.touch
+        expect(cart.version).to eq(2)
+      end
+    end
+
+    describe "#reassign" do
+      it "should rename the extra_keys if they exists" do
+        cart.extra['self_picking'] = true
+        cart.extra['discount'] = { applied: true, code: 'Z42XB12' }
+
+        cart.reassign(2)
+        expect(Cartman.config.redis.exists("cartman:cart:1:extra:self_picking")).to be false
+        expect(Cartman.config.redis.exists("cartman:cart:1:extra:discount")).to be false
+        expect(Cartman.config.redis.exists("cartman:cart:2:extra:self_picking")).to be true
+        expect(Cartman.config.redis.exists("cartman:cart:2:extra:discount")).to be true
+
+        cart.reassign(1)
+        expect(Cartman.config.redis.exists("cartman:cart:1:extra:self_picking")).to be true
+        expect(Cartman.config.redis.exists("cartman:cart:1:extra:discount")).to be true
+        expect(Cartman.config.redis.exists("cartman:cart:2:extra:self_picking")).to be false
+        expect(Cartman.config.redis.exists("cartman:cart:2:extra:discount")).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
I needed a way to store extra data with the Cart so I introduced Cart#extra[] property for that purpose. All tests are OK (I tested with Ruby 2.5.1 and Redis 4+) and I even added several samples in the README !

I also grabbed @cheezy2022 "BigDecimal" changes because they make senses to me.